### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=0.1.0
 author=Sara Damiano <sdamiano@stroudcenter.org>
 maintainer=Sara Damiano <sdamiano@stroudcenter.org>
 sentence=Arduino library for communicating with S::CAN instruments, either directly with a spectro::lyzer or to any instrument via ana::gate.
+paragraph=It is intended to allow spectro::lyzer data to be continuously uploaded to a network via wifi or cellular data streams without the very large power draw of a con::cube, con::stat, or con::lyte system.
 category=Sensors
 url=https://github.com/StroudCenter/S-CAN-Modbus
 architectures=avr,sam,samd


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format