### PR TITLE
Fix definition of getSystemTime keyword

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -48,7 +48,7 @@ getCleaningDuration	KEYWORD2
 setCleaningDuration	KEYWORD2
 getCleaningWait	KEYWORD2
 setCleaningWait	KEYWORD2
-uint32_t getSystemTime	KEYWORD2
+getSystemTime	KEYWORD2
 setSystemTime	KEYWORD2
 getMeasInterval	KEYWORD2
 setMeasInterval	KEYWORD2


### PR DESCRIPTION
The type was left in place before this keyword, which caused it to not be recognized by the Arduino IDE for special highlighting.